### PR TITLE
ampliando parâmetros de alertas

### DIFF
--- a/models/contracheques/contracheques.yml
+++ b/models/contracheques/contracheques.yml
@@ -24,7 +24,7 @@ models:
           - not_null:
               config: *common_config
           - dbt_expectations.expect_column_values_to_match_regex:
-              regex: "^[a-zA-ZÀ-ÖØ-öø-ÿ'']+(?: [a-zA-ZÀ-ÖØ-öø-ÿ'']+)*$"
+              regex: "^[a-zA-ZÀ-ÖØ-öø-ÿ''´]+(?:[- ][a-zA-ZÀ-ÖØ-öø-ÿ''´]+)*$"
               config: *common_config
           - dbt_utils.not_constant:
               config: *common_config


### PR DESCRIPTION
- ampliando a regex para aceitar acento agudo e hífen entre nomes, e.g. `D´AVILA` e `BEN-HUR` 
- aumentando a tolerância para 0.05 na comparação entre valores numéricos